### PR TITLE
reply(...).status is not a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ const handler = (route, options = {}) => async (request, reply) => {
 
     // Return result
     return reply(result)
-      .status(result.hasOwnProperty('data') ? 200 : 400);
+      .code(result.hasOwnProperty('data') ? 200 : 400);
   }
   catch (error) {
     // Return error


### PR DESCRIPTION
This causes an error on hapi 9.3.

I looked back to like, hapi 8, and it seems to be using `.code` back then as well.
