### PR TITLE
Added rootValue execution. Fixes #15

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,12 +186,23 @@ const createResult = async ({
     }
   }
 
+  // Execute rootValue functions if present
+  const executedRootValue = Object.keys(rootValue).reduce((accumulator, rootValueKey) => {
+    const rootValueValue = rootValue[rootValueKey];
+    if (typeof rootValueValue === 'function') {
+      accumulator[rootValueKey] = rootValueValue({}, request);
+    } else {
+      accumulator[rootValueKey] = rootValueValue;
+    }
+    return accumulator;
+  }, {});
+
   // Perform the execution, reporting any errors creating the context.
   try {
     return await execute(
       schema,
       documentAST,
-      rootValue,
+      executedRootValue,
       context,
       variables,
       operationName


### PR DESCRIPTION
This is to allow the injection of things like User ID's into rootValue from the request, for cases where the `/graphql` endpoint require authentication.

Example:

``` JS
server.register({
      register: GraphQL,
      options: {
        route: {
          path: '/graphql',
          config: {
            auth: 'token',
            tags: ['api']
          }
        },
        query: {
          schema: GraphQLSchema,
          graphiql: true,
          rootValue: {
            ip: function (args, request) {
              return request.info.remoteAddress;
            }
          },
          formatError: error => ({
            message: error.message,
            locations: error.locations,
            stack: error.stack
          })
        }
      }
    });
```

Relevant: http://graphql.org/graphql-js/authentication-and-express-middleware/
