### PR TITLE
Add index.d.ts stub for compatibility with TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+// Doesn't matter what register is named - hapi plugin expects a function to be
+// exported as the default.
+declare module "hapi-graphql" {
+  let register: () => any;
+  export default register;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-// Doesn't matter what register is named - hapi plugin expects a function to be
-// exported as the default.
 declare module "hapi-graphql" {
   let register: () => any;
   export default register;


### PR DESCRIPTION
This is a basic index.d.ts file that makes the module work out of the box with TypeScript.  Without types, TypeScript users (like us) like us may not give the module a shot.

The stub is fully functional with the example use case in readme.md (just assigns a generic function type to the default export).

(.d.ts files can be in DefinitelyTyped or bundled with the module, as with this pull request; the latter means one less step for users of the module.)

Thanks for taking a look!